### PR TITLE
Make the sudo usermod command generic

### DIFF
--- a/exercises/ansible_engine/10-molecule/README.md
+++ b/exercises/ansible_engine/10-molecule/README.md
@@ -22,7 +22,7 @@ To run docker commands as a non-priviledged user we need to create a docker grou
 
 ```bash
 sudo groupadd docker
-sudo usermod -a -G docker studentx
+sudo usermod -a -G docker $USER
 logout
 ssh studentx@X.X.X.X
 ```


### PR DESCRIPTION
Exchanged the static "studentx" for $USER that will be filled by bash with current username before executing sudo.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the role, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
